### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete multi-character sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "remark-gfm": "^4.0.1",
     "remark-toc": "^9.0.0",
     "swiper": "^11.2.5",
-    "vite": "^6.2.1"
+    "vite": "^6.2.1",
+    "striptags": "^3.2.0"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.10",

--- a/scripts/update-descriptions.js
+++ b/scripts/update-descriptions.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const { marked } = require('marked');
-
+const striptags = require('striptags');
 // Function to clean and extract text from markdown content
 function extractTextFromMarkdown(content) {
     // Remove frontmatter if any (shouldn't be present in content part)
@@ -16,7 +16,7 @@ function extractTextFromMarkdown(content) {
     content = content.replace(/!\[([^\]]*)\]\([^)]*\)/g, '');
     
     // Remove HTML tags
-    content = content.replace(/<[^>]*>/g, '');
+    content = striptags(content);
     
     // Remove extra whitespace and normalize
     content = content.replace(/\s+/g, ' ').trim();


### PR DESCRIPTION
Potential fix for [https://github.com/martinwoodward/martinwoodward.github.io/security/code-scanning/3](https://github.com/martinwoodward/martinwoodward.github.io/security/code-scanning/3)

The best way to fix this problem is to use a well-tested library for HTML sanitization or tag removal. In Node.js, the `sanitize-html` library is a popular choice, but if the goal is to remove all HTML tags and keep only plain text, the `striptags` library is more appropriate and lightweight. If using a library is not possible, a fallback is to repeatedly apply the regular expression replacement until no more matches are found, ensuring all tags are removed. For this code, the single best fix is to use the `striptags` library to remove all HTML tags from the content in `extractTextFromMarkdown`. This change should be made in the function on line 19, and the required import for `striptags` should be added at the top of the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
