### PR TITLE
Potential fix for code scanning alert no. 5: Replacement of a substring with itself

### DIFF
--- a/src/lib/utils/textConverter.ts
+++ b/src/lib/utils/textConverter.ts
@@ -51,7 +51,7 @@ export const formatCategoryForDisplay = (content: string, lowercase: boolean = f
   // Apply case transformation
   if (lowercase) {
     // Special handling for GitHub - keep the camelCase even in lowercase context
-    return result.replace(/\bGitHub\b/g, "GitHub").toLowerCase().replace(/\bgithub\b/g, "GitHub");
+    return result.toLowerCase().replace(/\bgithub\b/g, "GitHub");
   } else {
     result = result.replace(/^[a-z]/, function (m) {
       return m.toUpperCase();


### PR DESCRIPTION
Potential fix for [https://github.com/martinwoodward/martinwoodward.github.io/security/code-scanning/5](https://github.com/martinwoodward/martinwoodward.github.io/security/code-scanning/5)

To fix the problem, remove the redundant replacement of "GitHub" with itself on line 54. The correct approach is to lowercase the string and then replace all instances of "github" (in lowercase) with "GitHub" to restore the correct casing. This can be done by simply calling `.toLowerCase().replace(/\bgithub\b/g, "GitHub")` on the result. Only line 54 in `src/lib/utils/textConverter.ts` needs to be changed; no new imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
