### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-verification.yml
+++ b/.github/workflows/pr-verification.yml
@@ -1,6 +1,11 @@
 name: PR Verification
+
+# Sets permissions of the GITHUB_TOKEN to **not** allow deployment to GitHub Pages
 permissions:
-  contents: read
+  contents: write
+  pages: read
+  id-token: write
+  models: read
 
 on:
   pull_request:

--- a/.github/workflows/pr-verification.yml
+++ b/.github/workflows/pr-verification.yml
@@ -1,4 +1,6 @@
 name: PR Verification
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/martinwoodward/martinwoodward.github.io/security/code-scanning/7](https://github.com/martinwoodward/martinwoodward.github.io/security/code-scanning/7)

To fix the problem, explicitly set the `permissions` key at the top level of the workflow file. This will apply the specified permissions to all jobs in the workflow unless overridden at the job level. The minimal permission required for most CI workflows is `contents: read`, which allows the workflow to fetch repository contents but not to make any changes. This should be added immediately after the `name` field and before the `on` field (or after `on`, but before `jobs`). No changes to the jobs themselves are required unless a job needs additional permissions, in which case a more granular `permissions` block can be added to that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
