### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete URL substring sanitization

### DIFF
--- a/scripts/copy-missing-images.js
+++ b/scripts/copy-missing-images.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 const fs = require('fs');
 const path = require('path');
+const url = require('url');
 
 // Configuration
 const OLD_BLOG_PATH = '/Users/martin/src/blog';
@@ -39,6 +40,19 @@ function extractFrontmatter(filePath) {
     } catch (error) {
         console.error(`Error reading ${filePath}:`, error.message);
         return null;
+    }
+}
+
+// Helper function to check if a URL's host is woodwardweb.com
+function isWoodwardwebComHost(imageSrc) {
+    try {
+        // Only parse if it looks like a URL
+        if (!/^https?:\/\//i.test(imageSrc)) return false;
+        const parsed = url.parse(imageSrc);
+        // Accept only exact match to woodwardweb.com (no subdomains)
+        return parsed.host === 'woodwardweb.com';
+    } catch (e) {
+        return false;
     }
 }
 
@@ -168,7 +182,7 @@ function extractImagesFromOldPost(oldPostPath) {
                     imageSrc = path.join(OLD_BLOG_PATH, 'Open-Live-Writer', pathMatch[1]);
                     console.log(`     → Converted to: ${imageSrc}`);
                 }
-            } else if (imageSrc.includes('woodwardweb.com/')) {
+            } else if (isWoodwardwebComHost(imageSrc)) {
                 // Other woodwardweb.com images - try to find them
                 const pathMatch = imageSrc.match(/woodwardweb\.com\/(.+)$/);
                 if (pathMatch) {


### PR DESCRIPTION
Potential fix for [https://github.com/martinwoodward/martinwoodward.github.io/security/code-scanning/8](https://github.com/martinwoodward/martinwoodward.github.io/security/code-scanning/8)

To fix the problem, we should parse `imageSrc` as a URL and check its `host` property to ensure it matches `woodwardweb.com` (or any allowed subdomains, if desired). This avoids the pitfalls of substring matching. We should use Node's built-in `url` module (`require('url')`) to parse the URL. The fix should only affect the relevant `else if` block (line 171), replacing the substring check with a proper host check. We need to add the `url` module import at the top of the file if it is not already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
